### PR TITLE
Added Kickstart minimum version check at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore editor files
+.vscode/
+
 # Ignore object files and build artifacts
 *.o
 
@@ -5,6 +8,5 @@
 *.lnk
 
 # Ignore executable files
-releases
-*.lha
+releases/
 ShowProc

--- a/src/ShowProc.c
+++ b/src/ShowProc.c
@@ -16,6 +16,9 @@
 // Embed version tag into binary
 const char* version = VERSTAG;
 
+// Externs
+extern struct ExecBase* SysBase;
+
 // Function prototypes
 BYTE 	bstrlen(BSTR bstring);
 size_t 	bstr2cstr(BSTR bstring, char* buffer, size_t bufsize);
@@ -41,6 +44,12 @@ int main(void)
 	MODE 	mode = MODE_VERBOSE;
 	long	result;
 	int		rc = RETURN_OK;
+
+	// Check Kickstart version
+	if (SysBase->LibNode.lib_Version < KICKSTART_MIN_VER) {
+		Printf("%s\n", STR_OS_TOO_OLD);
+		return RETURN_FAIL;
+	}
 
 	// Capture current task priority & set the priority a bit higher to reduce
 	// the risk of changes occurring while reading the process & CLI info

--- a/src/ShowProc.h
+++ b/src/ShowProc.h
@@ -28,10 +28,17 @@ typedef enum MODE {
 #define OPT_COMMAND			6			// Searches for a process by command name
 #define OPT_COUNT 			7
 
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+#define KICKSTART_MIN_VER	37		// Minimum Kickstart version required (37 = 2.04)
+
+
 // --------------------------------------------------------------------------------
 // String constants
 // --------------------------------------------------------------------------------
 #define PROGRAM				"ShowProc"
+#define STR_OS_TOO_OLD		"This program requires Kickstart 2.04 or higher"
 #define STR_YES				"Yes"
 #define STR_NO				"No"
 #define STR_NO_COMMAND 		"No command loaded"


### PR DESCRIPTION
At startup, it now checks that Kickstart is at least the minimum required version (V37).